### PR TITLE
Modify clickSafe default.

### DIFF
--- a/lib/carousel.js
+++ b/lib/carousel.js
@@ -224,6 +224,8 @@ var Carousel = _react2['default'].createClass({
 
     if (self.props.swiping === false) {
       return null;
+    } else {
+      self.clickSafe = true;
     }
 
     return {
@@ -267,13 +269,15 @@ var Carousel = _react2['default'].createClass({
     };
   },
 
-  clickSafe: true,
+  clickSafe: false,
 
   getMouseEvents: function getMouseEvents() {
     var self = this;
 
     if (this.props.dragging === false) {
       return null;
+    } else {
+      self.clickSafe = true;
     }
 
     return {

--- a/src/carousel.js
+++ b/src/carousel.js
@@ -216,6 +216,8 @@ const Carousel = React.createClass({
 
     if (self.props.swiping === false) {
       return null;
+    } else {
+      self.clickSafe = true;
     }
 
     return {
@@ -265,13 +267,15 @@ const Carousel = React.createClass({
     }
   },
 
-  clickSafe: true,
+  clickSafe: false,
 
   getMouseEvents() {
     var self = this;
 
     if (this.props.dragging === false) {
       return null;
+    } else {
+      self.clickSafe = true;
     }
 
     return {


### PR DESCRIPTION
From https://github.com/FormidableLabs/nuka-carousel/pull/190

When both swiping and dragging are disabled, clickSafe isn't needed
yet it is set to true by default because the handleSwipe function
is never called to unset it after a click. This means the click event is
always blocked.

This change replaces that behaviour by defaulting clickSafe to false and
enabling it if either dragging or swiping.